### PR TITLE
#해시테이블, Closed Addressing - 체이닝 기법 간단 구현

### DIFF
--- a/src/dataStructures/hashtable/closedAddressing/MyHashTable.java
+++ b/src/dataStructures/hashtable/closedAddressing/MyHashTable.java
@@ -6,31 +6,73 @@ import dataStructures.hashtable.HashTable;
  * Closed Addressing, 체이닝 연습
  */
 public class MyHashTable implements HashTable {
+    Slot[] hashTable;
 
+    static class Slot {
+        String key;
+        String value;
+        Slot next;
+
+        Slot(String key, String value) {
+            this.key = key;
+            this.value = value;
+            next = null;
+        }
+    }
+
+    MyHashTable(int initialSize) {
+        hashTable = new Slot[initialSize];
+    }
 
     @Override
     public int hashFunc(String key) {
-        return 0;
+        return (int) (key.charAt(0)) % this.hashTable.length;
     }
 
     /**
      * Chaining 방식을 활용해서 해시테이블에 저장하기
+     *
      * @param key
      * @param value
      * @return
      */
     @Override
     public boolean saveData(String key, String value) {
-        return false;
+        int address = hashFunc(key);
+
+        /* 이미 동일한 key에 대한 슬롯이 있는 경우 */
+        if (this.hashTable[address] != null) {
+            Slot cursor = this.hashTable[address];
+            while (cursor.next != null) {
+                cursor = cursor.next;
+            }
+            cursor.next = new Slot(key, value);
+
+        } else {
+            this.hashTable[address] = new Slot(key, value);
+        }
+
+        return true;
     }
 
     /**
      * Chaining 방식을 고려하여, Key가 갖는 대한 링크드 리스트 순회 후 반환하기
+     *
      * @param key
      * @return
      */
     @Override
     public String getData(String key) {
-        return null;
+        int address = this.hashFunc(key);
+        StringBuilder sb = new StringBuilder();
+
+        if (this.hashTable[address] != null) {
+            Slot cursor = this.hashTable[address];
+            do {
+                sb.append(cursor.value).append(" ");
+                cursor = cursor.next;
+            } while (cursor != null);
+        }
+        return sb.toString();
     }
 }

--- a/src/dataStructures/hashtable/closedAddressing/MyHashTableTest.java
+++ b/src/dataStructures/hashtable/closedAddressing/MyHashTableTest.java
@@ -1,4 +1,28 @@
 package dataStructures.hashtable.closedAddressing;
 
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
 public class MyHashTableTest {
+    MyHashTable hashTable;
+
+    @Before
+    public void init(){
+        hashTable = new MyHashTable(20);
+    }
+
+
+    @Test
+    public void testHashCollision(){
+        hashTable.saveData("J", "Junho Choi");
+        hashTable.saveData("J", "James Choi");
+        hashTable.saveData("J", "Jenny Choi");
+        hashTable.saveData("H", "Henry Choi");
+        hashTable.saveData("D", "Diana Choi");
+        System.out.println(hashTable.getData("J"));
+        assertEquals("Jenny Choi James Choi Jenny Choi ", hashTable.getData("J"));
+    }
+
 }

--- a/src/dataStructures/hashtable/closedAddressing/SimpleTest.java
+++ b/src/dataStructures/hashtable/closedAddressing/SimpleTest.java
@@ -1,0 +1,17 @@
+package dataStructures.hashtable.closedAddressing;
+
+public class SimpleTest {
+    public static void main(String[] args) {
+        MyHashTable hashTable = new MyHashTable(20);
+        hashTable.saveData("J", "Junho Choi");
+        System.out.println(hashTable.getData("J"));
+        hashTable.saveData("J", "James Choi");
+        hashTable.saveData("J", "Jenny Choi");
+        hashTable.saveData("H", "Henry Choi");
+        hashTable.saveData("D", "Diana Choi");
+        System.out.println(hashTable.getData("J"));
+        System.out.println(hashTable.getData("H"));
+        hashTable.saveData("H", "Hunho Choi");
+        System.out.println(hashTable.getData("H"));
+    }
+}


### PR DESCRIPTION
String key, String value를 갖는 Slot에 대한 해시 테이블에 대해
key의 첫 알파벳의 ASCII 코드를 해시 테이블의 키로 변환하며 발생할 수 있는 문제를 간단히 해결한다.
예를 들어, {"J", "Junho Choi"}, {"J", "James Choi"} 와 같은 경우 충돌이 일어난다.
이에 대해 링크드 리스트를 활용하여 Closed Addressing 방법 중 Chaining 기법을 활용하는 간단한 예제이다.
